### PR TITLE
From credentials feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Loads environment variables from `.env` files and network services into `ENV`.
 
-DEnv is heavily inspired by [dotenv](https://github.com/bkeepers/dotenv) 
-and tries to follow its lead when dealing with `.env` files. 
+DEnv is heavily inspired by [dotenv](https://github.com/bkeepers/dotenv)
+and tries to follow its lead when dealing with `.env` files.
 Where it departs is that it connects to network services like [Consul](https://www.consul.io/)
 to obtain environment variables.
 
@@ -32,9 +32,9 @@ DEnv.from_file! '../.env'
 ```
 
 This will look for a `.env` file in the parent directory and update the `ENV` with the variables defined in that file.
- 
+
 ### What if you want to check the changes first?
-  
+
 ```ruby
 DEnv.from_file('../.env').changes
 # => {'A' => '1', 'B' => 2 }
@@ -43,8 +43,8 @@ DEnv.env!
 ```
 
 ### What if I have multiple files?
- 
-You can list all the files you need to use and `DEnv` will load them in the same order. 
+
+You can list all the files you need to use and `DEnv` will load them in the same order.
 This allows for one file to override the values in the other.
 
 ```ruby
@@ -65,11 +65,11 @@ DEnv.from_file('../.env').from_file('../.local.env').env!
 # Or alternatively
 DEnv.from_file('../.env').from_file!('../.local.env')
 ```
-  
+
 ### Can I make it reload?
 
 Yes, you can! This will reload from known sources and update ENV:
- 
+
  ```ruby
 DEnv.reload.env!
 # or alternatively
@@ -77,15 +77,15 @@ DEnv.reload!
 ```
 
 ### What if I'm really clever?
-  
+
 Yes, you can use the newly found environment variables for the next step. Something like:
- 
+
 ```ruby
 DEnv.from_file('../.env').from_file!('../.local.env')
 DEnv.from_consul!(ENV['CONSUL_URL'], ENV['CONSUL_PATH'])
 ```
 
-You might be pushing it but if that is your thing, go ahead! 
+You might be pushing it but if that is your thing, go ahead!
 
 ### Can I make it reload periodically!
 
@@ -104,9 +104,9 @@ Or you can use our little ext (not loaded by default):
 ```ruby
 # reload ENV every 30 seconds
 require 'denv/periodical'
-DEnv.reload_periodically! 30 
+DEnv.reload_periodically! 30
 ```
-  
+
 ### What about consul?
 
 You can connect to [Consul](https://www.consul.io/) and grab all the key/value pairs in one folder like so:
@@ -119,23 +119,54 @@ DEnv.from_consul!(url, path)
 options = { user: 'some_user', password: 'some_password' }
 DEnv.from_consul!(url, path, options)
 ```
-Please note the pattern that the `url` has an ending `/` and  that the `path` does not start with a `/` 
+Please note the pattern that the `url` has an ending `/` and  that the `path` does not start with a `/`
 or has the `v1/kv/` prefix.
+
+### What about using Rails credentials?
+
+You can use `#from_credentials` like so:
+```ruby
+# from your Rails app
+credentials = Rails.application.credentials[:your_source_here] # => { :ONE => '1', :TWO => '2' }
+DEnv.from_credentials(credentials)
+DEnv.env!
+# or
+DEnv.from_credentials!(credentials)
+```
+
+#### Reloading is supported with Rails credentials
+
+```ruby
+# from your Rails app
+credentials_location = :development
+credentials = Rails.application.credentials[credentials_location] # => { :ONE => '1', :TWO => '2' }
+DEnv.from_credentials!(credentials, credentials_location: credentials_location)
+
+# after you have edited your credentials.yml.enc
+
+DEnv.reload.env!
+# or
+DEnv.reload!
+```
+Please note:
+  - By not setting the credentials_location you will not be able to reload
+  - `#reload` after using `#from_credentials` outside of a Rails app will raise
+      a Runtime error
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. 
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests.
 You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. 
-To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, 
-which will create a git tag for the version, push git commits and tags, and push the `.gem` file 
+To install this gem onto your local machine, run `bundle exec rake install`.
+To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`,
+which will create a git tag for the version, push git commits and tags, and push the `.gem` file
 to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/acima-credit/denv. 
-This project is intended to be a safe, welcoming space for collaboration, and contributors are expected 
+Bug reports and pull requests are welcome on GitHub at https://github.com/acima-credit/denv.
+This project is intended to be a safe, welcoming space for collaboration, and contributors are expected
 to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 

--- a/lib/denv.rb
+++ b/lib/denv.rb
@@ -13,6 +13,7 @@ require 'denv/sources/set'
 require 'denv/sources/base'
 require 'denv/sources/file'
 require 'denv/sources/consul'
+require 'denv/sources/rails_credentials'
 
 require 'denv/changes/entry'
 require 'denv/changes/set'

--- a/lib/denv/sources/rails_credentials.rb
+++ b/lib/denv/sources/rails_credentials.rb
@@ -29,12 +29,16 @@ class DEnv
       private
 
       def load_new_creds
-        return nil if credentials_location.nil? || credentials_location == ''
-        return nil unless Object.const_defined?(:Rails)
-        return nil if ::Rails&.application&.credentials.nil?
+        if credentials_location.nil? || credentials_location == ''
+          return nil
+        elsif !Object.const_defined?(:Rails)
+          raise 'Cannot load credentials outside of Rails'
+        elsif ::Rails&.application&.credentials.nil?
+          raise 'Cannot load credentials when nil'
+        end
 
         hash = YAML.safe_load(::Rails.application.credentials.read)
-        @credentials_hash = hash[credentials_location]
+        @credentials_hash = hash[credentials_location.to_s]
       end
 
       def set_entries

--- a/lib/denv/sources/rails_credentials.rb
+++ b/lib/denv/sources/rails_credentials.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+class DEnv
+  class Sources
+    # Class for loading credentials specifically from Rails
+    class RailsCredentials < Base
+      attr_reader :credentials_hash, :credentials_location
+
+      def initialize(credentials_hash, credentials_location)
+        @credentials_hash = credentials_hash || {}
+        @credentials_location = credentials_location
+      end
+
+      def type
+        'credentials'
+      end
+
+      def key
+        "#{type[0, 1]}:credentials"
+      end
+
+      def reload
+        load_new_creds
+        super
+      end
+
+      private
+
+      def load_new_creds
+        return nil if credentials_location.nil? || credentials_location == ''
+        return nil unless Object.const_defined?(:Rails)
+        return nil if ::Rails&.application&.credentials.nil?
+
+        hash = YAML.safe_load(::Rails.application.credentials.read)
+        @credentials_hash = hash[credentials_location]
+      end
+
+      def set_entries
+        if credentials_hash == {}
+          DEnv.logger.error format('DEnv : source  : %-15.15s | %s', key, "could not find credentials")
+          return false
+        end
+
+        DEnv.logger.debug format('DEnv : source  : %-15.15s | %s', key, "found credentials")
+        credentials_hash.each do |key, value|
+          add(key.to_s, value.to_s)
+        end
+      end
+    end
+  end
+
+  def self.from_credentials(credentials_hash, credentials_location: nil)
+    add(Sources::RailsCredentials.new(credentials_hash, credentials_location))
+  end
+
+  def self.from_credentials!(credentials_hash, credentials_location: nil)
+    from_credentials(credentials_hash, credentials_location: credentials_location)
+    env!
+  end
+end

--- a/lib/denv/version.rb
+++ b/lib/denv/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class DEnv
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/integration/denv_spec.rb
+++ b/spec/integration/denv_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe DEnv, :clean_env do
-  it('version') { expect(DEnv::VERSION).to eq '0.1.0' }
+  it('version') { expect(DEnv::VERSION).to eq '0.2.0' }
 
   context 'with', :integration, :clean_env do
     let(:new_env) { { 'A' => '8', 'D' => '7', 'E' => 'extra' } }
@@ -14,6 +14,9 @@ RSpec.describe DEnv, :clean_env do
     let(:local_key) { %(f:#{::File.basename(local_path)}) }
     let(:consul_args) { ['https://consul.some-domain.com/', 'service/some_app/vars/', { user: 'some_user', password: 'some_password' }] }
     let(:consul_key) { 'c:consul.some-domain.com:service/some_app/vars/' }
+    let(:credentials_hash) { { Z: 'Z value', Y: 'Y value' } }
+    let(:credentials_location) { nil }
+    let(:cred_key) { %(c:credentials) }
 
     context 'change and update always' do
       shared_examples 'a valid setup and update' do
@@ -39,11 +42,31 @@ RSpec.describe DEnv, :clean_env do
         let(:exp_env) { new_env.update exp_changes }
         it_behaves_like 'a valid setup and update'
       end
+      context 'rails_credentials' do
+        before { DEnv.from_credentials(credentials_hash, credentials_location: nil) }
+        let(:exp_keys) { [cred_key] }
+        let(:exp_changes) { { 'Z' => 'Z value', 'Y' => 'Y value' } }
+        let(:exp_env) { {} }
+        let(:exp_env) { new_env.update exp_changes }
+        it_behaves_like 'a valid setup and update'
+      end
       context 'both .env and .local.env files' do
         before { DEnv.from_file(env_path).from_file(local_path) }
         let(:exp_keys) { [env_key, local_key] }
         let(:exp_changes) { { 'A' => '1', 'B' => '3', 'C' => '5' } }
         let(:exp_env) { { 'A' => '1', 'D' => '7', 'E' => 'extra', 'B' => '3', 'C' => '5' } }
+        it_behaves_like 'a valid setup and update'
+      end
+      context 'all .env, .local.env and rails_credentials' do
+        before do
+          DEnv
+            .from_file(env_path)
+            .from_file(local_path)
+            .from_credentials(credentials_hash, credentials_location: credentials_location)
+        end
+        let(:exp_keys) { [env_key, local_key, cred_key] }
+        let(:exp_changes) { { 'A' => '1', 'B' => '3', 'C' => '5', 'Y' => 'Y value', 'Z' => 'Z value' } }
+        let(:exp_env) { { 'A' => '1', 'D' => '7', 'E' => 'extra', 'B' => '3', 'C' => '5', 'Y' => 'Y value', 'Z' => 'Z value' } }
         it_behaves_like 'a valid setup and update'
       end
     end
@@ -63,6 +86,11 @@ RSpec.describe DEnv, :clean_env do
       context '.local.env file' do
         before { DEnv.from_file(local_path) }
         let(:exp_env) { new_env.merge 'B' => '3', 'C' => '5' }
+        it_behaves_like 'a valid setup and update'
+      end
+      context 'rails_credentials' do
+        before { DEnv.from_credentials(credentials_hash, credentials_location: credentials_location) }
+        let(:exp_env) { new_env.merge 'Y' => 'Y value', 'Z' => 'Z value' }
         it_behaves_like 'a valid setup and update'
       end
       context 'both .env and .local.env files' do
@@ -100,6 +128,12 @@ RSpec.describe DEnv, :clean_env do
         let(:exp_env) { { 'A' => '7', 'D' => '9', 'E' => 'extra' } }
         it_behaves_like 'a valid update!'
       end
+      context 'rails_credentials' do
+        before { DEnv.from_credentials!(credentials_hash, credentials_location: credentials_location) }
+        let(:exp_keys) { [cred_key] }
+        let(:exp_env) { new_env.merge('Z' => 'Z value', 'Y' => 'Y value') }
+        it_behaves_like 'a valid update!'
+      end
       context 'both .env and .local.env files' do
         before { DEnv.from_file(env_path).from_file!(local_path) }
         let(:exp_keys) { [env_key, local_key] }
@@ -130,19 +164,41 @@ RSpec.describe DEnv, :clean_env do
     end
 
     context 'reload! and reload! and reload!' do
-      let(:new_env) { { 'B' => '0' } }
-      let(:changes) { new_env.update 'B' => '2' }
-      let(:env_path) { '../envs/b/.env' }
-      let(:local_path) { '../envs/b/.local.env' }
-      it 'works' do
-        DEnv.from_file(env_path).from_file!(local_path)
-        expect(ENV.to_hash).to eq(changes)
-        DEnv.reload!
-        expect(ENV.to_hash).to eq(changes)
-        DEnv.reload!
-        expect(ENV.to_hash).to eq(changes)
-        DEnv.reload!
-        expect(ENV.to_hash).to eq(changes)
+      context 'with out rails_credentials' do
+        let(:new_env) { { 'B' => '0' } }
+        let(:changes) { new_env.update 'B' => '2' }
+        let(:env_path) { '../envs/b/.env' }
+        let(:local_path) { '../envs/b/.local.env' }
+        it 'works' do
+          DEnv.from_file(env_path).from_file!(local_path)
+          expect(ENV.to_hash).to eq(changes)
+          DEnv.reload!
+          expect(ENV.to_hash).to eq(changes)
+          DEnv.reload!
+          expect(ENV.to_hash).to eq(changes)
+          DEnv.reload!
+          expect(ENV.to_hash).to eq(changes)
+        end
+      end
+      context 'with rails_credentials' do
+        let(:new_env) { { 'B' => '0' } }
+        let(:changes) { new_env.update('B' => '2', 'Y' => 'Y value', 'Z' => 'Z value') }
+        let(:env_path) { '../envs/b/.env' }
+        let(:local_path) { '../envs/b/.local.env' }
+        it 'works', :aggregate_failures do
+          DEnv
+            .from_file(env_path)
+            .from_file(local_path)
+            .from_credentials!(credentials_hash, credentials_location: credentials_location)
+
+          expect(ENV.to_hash).to eq(changes)
+          DEnv.reload!
+          expect(ENV.to_hash).to eq(changes)
+          DEnv.reload!
+          expect(ENV.to_hash).to eq(changes)
+          DEnv.reload!
+          expect(ENV.to_hash).to eq(changes)
+        end
       end
     end
 

--- a/spec/integration/denv_spec.rb
+++ b/spec/integration/denv_spec.rb
@@ -185,6 +185,18 @@ RSpec.describe DEnv, :clean_env do
         let(:changes) { new_env.update('B' => '2', 'Y' => 'Y value', 'Z' => 'Z value') }
         let(:env_path) { '../envs/b/.env' }
         let(:local_path) { '../envs/b/.local.env' }
+        let(:credentials_location) { 'test' }
+        let(:application_double) { double(credentials: credentials_double) }
+        let(:credentials_double) { double(read: edited_creds) }
+        let(:rails_double) { double(application: application_double) }
+        let(:edited_creds) do
+          "test:\n" \
+          "  Y: 'Y value'\n" \
+          '  Z: \'Z value\''
+        end
+
+        before { stub_const("Rails", rails_double) }
+
         it 'works', :aggregate_failures do
           DEnv
             .from_file(env_path)

--- a/spec/unit/sources/rails_credentials_spec.rb
+++ b/spec/unit/sources/rails_credentials_spec.rb
@@ -67,7 +67,8 @@ RSpec.describe DEnv::Sources::RailsCredentials, :unit do
         let(:credentials_location) { 'test' }
 
         it 'reloads but does not return the new edited_creds' do
-          expect(subject.reload).to eq(credentials_hash)
+          expect{subject.reload}
+            .to raise_error('Cannot load credentials outside of Rails')
         end
       end
 

--- a/spec/unit/sources/rails_credentials_spec.rb
+++ b/spec/unit/sources/rails_credentials_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DEnv::Sources::RailsCredentials, :unit do
+  include SourceSpecHelpers
+
+  let(:credentials_location) { nil }
+  let(:credentials_hash) { { A: 1, 'B' => 2 } }
+  subject { described_class.new(credentials_hash, credentials_location) }
+  let(:exp_type) { 'credentials' }
+  let(:exp_key) { 'c:credentials' }
+
+  context 'hash present' do
+    let(:exp_hsh) { { 'A' => '1', 'B' => '2' } }
+    it_behaves_like 'a valid source'
+  end
+
+  context 'hash missing' do
+    let(:credentials_hash) { {} }
+    let(:exp_hsh) { {} }
+    it_behaves_like 'a valid source'
+  end
+
+  describe '#reload' do
+    context 'in a rails application' do
+      context 'with credentials_location' do
+        let(:edited_creds) do
+          "test:\n" \
+          "  A: 2\n" \
+          '  B: 1'
+        end
+        let(:application_double) { double(credentials: credentials_double) }
+        let(:credentials_double) { double(read: edited_creds) }
+        let(:rails_double) { double(application: application_double) }
+        let(:credentials_location) { 'test' }
+        let(:exp_hsh) { { 'A' => 2, 'B' => 1 } }
+
+        before { stub_const("Rails", rails_double) }
+
+        it 'reloads and returns the new edited_creds' do
+          expect(subject.reload).to eq(exp_hsh)
+        end
+      end
+
+      context 'without credentials_location' do
+        let(:edited_creds) do
+          "test:\n" \
+          "  A: 2\n" \
+          '  B: 1'
+        end
+        let(:application_double) { double(credentials: credentials_double) }
+        let(:credentials_double) { double(read: edited_creds) }
+        let(:rails_double) { double(application: application_double) }
+        let(:credentials_location) { nil }
+
+        before { stub_const("Rails", rails_double) }
+
+        it 'reloads but does not return the new edited_creds' do
+          expect(subject.reload).to eq(credentials_hash)
+        end
+      end
+    end
+
+    context 'not in a rails application' do
+      context 'with credentials_location' do
+        let(:credentials_location) { 'test' }
+
+        it 'reloads but does not return the new edited_creds' do
+          expect(subject.reload).to eq(credentials_hash)
+        end
+      end
+
+      context 'without credentials_location' do
+        let(:credentials_location) { nil }
+
+        it 'reloads but does not return the new edited_creds' do
+          expect(subject.reload).to eq(credentials_hash)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
To allow more sources of env vars creating a new `from_credentials` approach that will be used in the sense of: 
```ruby
DEnv.from_crednetials!(Rails.application.credentials.development) # or any entry point into credentials.
```
This will allow for loading env vars that can stay the same between environments.
I had this specifically in mind for keeping development environments in sync.