### PR TITLE
Minor Namespace Fix

### DIFF
--- a/lib/denv/changes/set.rb
+++ b/lib/denv/changes/set.rb
@@ -2,7 +2,7 @@
 
 class DEnv
   class Changes
-    class Set < SimpleDelegator
+    class Set < ::SimpleDelegator
       def initialize
         super []
       end

--- a/lib/denv/version.rb
+++ b/lib/denv/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class DEnv
-  VERSION = '0.3.3'
+  VERSION = '0.3.4'
 end


### PR DESCRIPTION
I'm seeing the following when running specs in CommonLogger.

```ruby
Failure/Error: require "denv"

NameError:
  uninitialized constant DEnv::Changes::SimpleDelegator
# /Users/adam.lauper/.rvm/gems/ruby-2.7.2/bundler/gems/denv-e1f56646335d/lib/denv/changes/set.rb:5:in `<class:Changes>'
# /Users/adam.lauper/.rvm/gems/ruby-2.7.2/bundler/gems/denv-e1f56646335d/lib/denv/changes/set.rb:4:in `<class:DEnv>'
# /Users/adam.lauper/.rvm/gems/ruby-2.7.2/bundler/gems/denv-e1f56646335d/lib/denv/changes/set.rb:3:in `<top (required)>'
# /Users/adam.lauper/.rvm/gems/ruby-2.7.2/bundler/gems/denv-e1f56646335d/lib/denv.rb:20:in `require'
# /Users/adam.lauper/.rvm/gems/ruby-2.7.2/bundler/gems/denv-e1f56646335d/lib/denv.rb:20:in `<top (required)>'
# ./lib/common_logger/colors.rb:3:in `require'
```

Add the `::` prefix fixes this issue.